### PR TITLE
Fix some minor bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ assets/f0editor_userdata/f0_presets/
 assets/f0editor_userdata/session/
 assets/datasets/
 assets/audios/audio-others/
+assets/training_presets/
 logs/
 rvc/models/pretraineds/
 rvc/models/pretraineds/hifi-gan

--- a/core.py
+++ b/core.py
@@ -1867,8 +1867,8 @@ def parse_arguments():
         "--process_effects",
         type=lambda x: bool(strtobool(x)),
         choices=[True, False],
-        help="Disable all filters during preprocessing.",
-        default=False,
+        help="Enable high-pass filtering during preprocessing.",
+        default=True,
     )
     preprocess_parser.add_argument(
         "--noise_reduction",

--- a/rvc/infer/infer.py
+++ b/rvc/infer/infer.py
@@ -285,7 +285,6 @@ class VoiceConverter:
                 .strip("\n")
                 .strip('"')
                 .strip()
-                .replace("trained", "added")
                 if index_path and os.path.exists(index_path) else ""
             )
 


### PR DESCRIPTION
- Use high-pass filter in preprocessing by default
  - This argument was flipped and had invalid description
- .gitignore training_presets
  - Training presets should be ignored by git, they're not a part of the repo
- Fix index file path string replacement
  - Until now, any index file path that contained string `trained` got malformed and silently rejected later due to being invalid